### PR TITLE
Simplify naming of constructor functions for query attributes

### DIFF
--- a/internal/engine/testhelp.go
+++ b/internal/engine/testhelp.go
@@ -97,7 +97,7 @@ func cmpQResults(t *testing.T, q *query.Query, exp []*core.Point, act []*core.Po
 
 func testQuery(t *testing.T, io PointIO, mints time.Time, maxts time.Time, exp []*core.Point) {
 
-	q := query.NewQuery(mints, maxts, query.NewQATrue())
+	q := query.NewQuery(mints, maxts, query.True())
 	qe, err := io.Search(q)
 	if err != nil {
 		t.Fatalf("unexpected error when initiating query %s: %s", q.String(), err.Error())

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -10,14 +10,14 @@ func TestCreate(t *testing.T) {
 	t2 := time.Date(2024, 01, 12, 13, 0, 0, 0, time.UTC)
 	t4 := time.Date(2024, 01, 14, 13, 0, 0, 0, time.UTC)
 
-	q := NewQuery(t2, t4, NewQATrue())
+	q := NewQuery(t2, t4, True())
 	exp := "[2024-01-12 13:00:00 +0000 UTC-2024-01-14 13:00:00 +0000 UTC] [true]"
 	if q.String() != exp {
 		t.Errorf("expected string %s got %s", exp, q.String())
 	}
 
 	// make sure start/end inversion is accounted for
-	q = NewQuery(t4, t2, NewQATrue())
+	q = NewQuery(t4, t2, True())
 	if q.String() != exp {
 		t.Errorf("expected string %s got %s", exp, q.String())
 	}
@@ -30,7 +30,7 @@ func TestCmpTime(t *testing.T) {
 	t4 := time.Date(2024, 01, 14, 13, 0, 0, 0, time.UTC)
 	t5 := time.Date(2024, 01, 15, 13, 0, 0, 0, time.UTC)
 
-	q := NewQuery(t2, t4, NewQATrue())
+	q := NewQuery(t2, t4, True())
 
 	fn := func(ts time.Time, exp int) {
 		act := q.CmpTime(core.NewPoint(ts))
@@ -96,20 +96,20 @@ func TestQueryAttrs(t *testing.T) {
 	}
 
 	// things that are true
-	t1 := NewQAEqual("color", "blue")
-	t2 := NewQAEqual("animal", "moose")
-	t3 := NewQARegex("index", `^\d+$`)
-	t4 := NewQAEqual("shape", "square")
+	t1 := Equal("color", "blue")
+	t2 := Equal("animal", "moose")
+	t3 := Regex("index", `^\d+$`)
+	t4 := Equal("shape", "square")
 
 	// things that are false
-	f1 := NewQARegex("color", "^x")
-	f2 := NewQARegex("animal", "mo{3,5}se")
-	f3 := NewQAEqual("index", "777")
-	f4 := NewQARegex("flavor", "sour")
+	f1 := Regex("color", "^x")
+	f2 := Regex("animal", "mo{3,5}se")
+	f3 := Equal("index", "777")
+	f4 := Regex("flavor", "sour")
 
-	fn(NewQATrue(), true)
-	fn(NewQAExists("color"), true)
-	fn(NewQAExists("flavor"), false)
+	fn(True(), true)
+	fn(Exists("color"), true)
+	fn(Exists("flavor"), false)
 	fn(t1, true)
 	fn(t2, true)
 	fn(t3, true)
@@ -118,9 +118,9 @@ func TestQueryAttrs(t *testing.T) {
 	fn(f2, false)
 	fn(f3, false)
 	fn(f4, false)
-	fn(NewQAOr(NewQAExists("flavor"), f1, f2, f3, f4), false)
-	fn(NewQAOr(NewQAExists("flavor"), t1, f2, f3, f4), true)
-	fn(NewQAOr(NewQAAnd(f1, f2, f3, f4), NewQANot(t1), NewQAOr(NewQANot(f4), t2, t3)), true)
-	fn(NewQAOr(NewQAAnd(f1, f2, f3, f4), NewQANot(t4), NewQAOr(NewQANot(t4), f3)), false)
+	fn(Or(Exists("flavor"), f1, f2, f3, f4), false)
+	fn(Or(Exists("flavor"), t1, f2, f3, f4), true)
+	fn(Or(And(f1, f2, f3, f4), Not(t1), Or(Not(f4), t2, t3)), true)
+	fn(Or(And(f1, f2, f3, f4), Not(t4), Or(Not(t4), f3)), false)
 
 }

--- a/internal/query/queryattr.go
+++ b/internal/query/queryattr.go
@@ -29,7 +29,7 @@ func (qa *QATrue) Match(attrs map[string]string) bool { return true }
 func (qa *QATrue) String() string { return "true" }
 
 // Returns new QATrue object
-func NewQATrue() *QATrue {
+func True() *QATrue {
 	return &QATrue{}
 }
 
@@ -53,7 +53,7 @@ func (qa *QAExists) String() string {
 }
 
 // Returns new QAExists object with specified attribute key
-func NewQAExists(k string) *QAExists {
+func Exists(k string) *QAExists {
 	return &QAExists{k: k}
 }
 
@@ -82,7 +82,7 @@ func (qa *QAEqual) String() string {
 }
 
 // Returns new QAEqual object with specified attribute key and value
-func NewQAEqual(k string, v string) *QAEqual {
+func Equal(k string, v string) *QAEqual {
 	return &QAEqual{k: k, v: v}
 }
 
@@ -112,7 +112,7 @@ func (qa *QARegex) String() string {
 
 // Returns new QARegex object with specified attribute key and regex to use
 // when comparing against values.
-func NewQARegex(k string, regex string) *QARegex {
+func Regex(k string, regex string) *QARegex {
 	re := regexp.MustCompile(regex)
 	return &QARegex{k: k, re: re}
 }
@@ -137,7 +137,7 @@ func (qa *QANot) String() string {
 
 // Returns new QANot object that's the logical inversion of the specified
 // QueryAttr
-func NewQANot(qa QueryAttr) *QANot {
+func Not(qa QueryAttr) *QANot {
 	return &QANot{qa: qa}
 }
 
@@ -177,7 +177,7 @@ func (qa *QAAnd) String() string {
 
 // Returns new QAAnd object that's the logical inversion of the specified
 // QueryAttr
-func NewQAAnd(qa ...QueryAttr) *QAAnd {
+func And(qa ...QueryAttr) *QAAnd {
 	return &QAAnd{qa: qa}
 }
 
@@ -217,6 +217,6 @@ func (qa *QAOr) String() string {
 
 // Returns new QAOr object that's the logical inversion of the specified
 // QueryAttr
-func NewQAOr(qa ...QueryAttr) *QAOr {
+func Or(qa ...QueryAttr) *QAOr {
 	return &QAOr{qa: qa}
 }

--- a/internal/query/queryattr_test.go
+++ b/internal/query/queryattr_test.go
@@ -43,172 +43,172 @@ func TestAttrString(t *testing.T) {
 		}
 	}
 
-	fn(t, NewQATrue(), "true")
-	fn(t, NewQAEqual("color", "blue"), "color == 'blue'")
-	fn(t, NewQARegex("color", "blue"), "color =~ /blue/")
-	fn(t, NewQAExists("color"), "color exists")
+	fn(t, True(), "true")
+	fn(t, Equal("color", "blue"), "color == 'blue'")
+	fn(t, Regex("color", "blue"), "color =~ /blue/")
+	fn(t, Exists("color"), "color exists")
 
-	t1 := NewQAEqual("color", "blue")
-	t2 := NewQAEqual("animal", "moose")
-	t3 := NewQAEqual("shape", "square")
+	t1 := Equal("color", "blue")
+	t2 := Equal("animal", "moose")
+	t3 := Equal("shape", "square")
 
-	fn(t, NewQANot(t1), "!(color == 'blue')")
-	fn(t, NewQAOr(t2, t3), "(animal == 'moose') || (shape == 'square')")
-	fn(t, NewQAAnd(t2, t3), "(animal == 'moose') && (shape == 'square')")
-	fn(t, NewQAAnd(t2, NewQANot(t3)), "(animal == 'moose') && (!(shape == 'square'))")
+	fn(t, Not(t1), "!(color == 'blue')")
+	fn(t, Or(t2, t3), "(animal == 'moose') || (shape == 'square')")
+	fn(t, And(t2, t3), "(animal == 'moose') && (shape == 'square')")
+	fn(t, And(t2, Not(t3)), "(animal == 'moose') && (!(shape == 'square'))")
 }
 
 func TestAttrTrue(t *testing.T) {
 	a := testGetAttrs()
-	runQATest(t, a, NewQATrue(), true)
+	runQATest(t, a, True(), true)
 }
 
 func TestAttrExists(t *testing.T) {
 	a := testGetAttrs()
-	runQATest(t, a, NewQAExists("color"), true)
-	runQATest(t, a, NewQAExists("animal"), true)
-	runQATest(t, a, NewQAExists("shape"), true)
-	runQATest(t, a, NewQAExists("Color"), false) // case sensitive
-	runQATest(t, a, NewQAExists("flavor"), false)
-	runQATest(t, a, NewQAExists("hue"), false)
+	runQATest(t, a, Exists("color"), true)
+	runQATest(t, a, Exists("animal"), true)
+	runQATest(t, a, Exists("shape"), true)
+	runQATest(t, a, Exists("Color"), false) // case sensitive
+	runQATest(t, a, Exists("flavor"), false)
+	runQATest(t, a, Exists("hue"), false)
 }
 
 func TestAttrEqual(t *testing.T) {
 	a := testGetAttrs()
-	runQATest(t, a, NewQAEqual("color", "blue"), true)
-	runQATest(t, a, NewQAEqual("color", "red"), false)
-	runQATest(t, a, NewQAEqual("flavor", "sour"), false) // missing
-	runQATest(t, a, NewQAEqual("color", "Blue"), false)  // case sensitive
-	runQATest(t, a, NewQAEqual("Color", "blue"), false)  // case sensitive
-	runQATest(t, a, NewQAEqual("color", "blu"), false)   // contains
+	runQATest(t, a, Equal("color", "blue"), true)
+	runQATest(t, a, Equal("color", "red"), false)
+	runQATest(t, a, Equal("flavor", "sour"), false) // missing
+	runQATest(t, a, Equal("color", "Blue"), false)  // case sensitive
+	runQATest(t, a, Equal("Color", "blue"), false)  // case sensitive
+	runQATest(t, a, Equal("color", "blu"), false)   // contains
 }
 
 func TestAttrRegex(t *testing.T) {
 	a := testGetAttrs()
-	runQATest(t, a, NewQARegex("color", "blue"), true)
-	runQATest(t, a, NewQARegex("color", "red"), false)
-	runQATest(t, a, NewQARegex("flavor", "sour"), false) // missing
-	runQATest(t, a, NewQARegex("color", "Blue"), false)  // case sensitive
-	runQATest(t, a, NewQARegex("Color", "blue"), false)  // case sensitive
-	runQATest(t, a, NewQARegex("color", "blu"), true)    // contains
+	runQATest(t, a, Regex("color", "blue"), true)
+	runQATest(t, a, Regex("color", "red"), false)
+	runQATest(t, a, Regex("flavor", "sour"), false) // missing
+	runQATest(t, a, Regex("color", "Blue"), false)  // case sensitive
+	runQATest(t, a, Regex("Color", "blue"), false)  // case sensitive
+	runQATest(t, a, Regex("color", "blu"), true)    // contains
 
 	// now we get into regexp metacharacters
-	runQATest(t, a, NewQARegex("color", "blu."), true)
-	runQATest(t, a, NewQARegex("color", "^bl"), true)
-	runQATest(t, a, NewQARegex("color", "ue$"), true)
-	runQATest(t, a, NewQARegex("color", "^x"), false)
-	runQATest(t, a, NewQARegex("color", "blu$"), false)
+	runQATest(t, a, Regex("color", "blu."), true)
+	runQATest(t, a, Regex("color", "^bl"), true)
+	runQATest(t, a, Regex("color", "ue$"), true)
+	runQATest(t, a, Regex("color", "^x"), false)
+	runQATest(t, a, Regex("color", "blu$"), false)
 
-	runQATest(t, a, NewQARegex("animal", "mo+se"), true)
-	runQATest(t, a, NewQARegex("animal", "mo.se"), true)
-	runQATest(t, a, NewQARegex("animal", "mo*se"), true)
-	runQATest(t, a, NewQARegex("animal", "mo{1,5}se"), true)
-	runQATest(t, a, NewQARegex("animal", "mo{3,5}se"), false)
-	runQATest(t, a, NewQARegex("index", `^\d+$`), true)
-	runQATest(t, a, NewQARegex("index", `^\D+$`), false)
+	runQATest(t, a, Regex("animal", "mo+se"), true)
+	runQATest(t, a, Regex("animal", "mo.se"), true)
+	runQATest(t, a, Regex("animal", "mo*se"), true)
+	runQATest(t, a, Regex("animal", "mo{1,5}se"), true)
+	runQATest(t, a, Regex("animal", "mo{3,5}se"), false)
+	runQATest(t, a, Regex("index", `^\d+$`), true)
+	runQATest(t, a, Regex("index", `^\D+$`), false)
 }
 
 func TestAttrNot(t *testing.T) {
 	a := testGetAttrs()
 
 	// things that are true
-	t1 := NewQAEqual("color", "blue")
-	t2 := NewQAEqual("animal", "moose")
-	t3 := NewQARegex("index", `^\d+$`)
-	t4 := NewQAEqual("shape", "square")
+	t1 := Equal("color", "blue")
+	t2 := Equal("animal", "moose")
+	t3 := Regex("index", `^\d+$`)
+	t4 := Equal("shape", "square")
 
 	// things that are false
-	f1 := NewQARegex("color", "^x")
-	f2 := NewQARegex("animal", "mo{3,5}se")
-	f3 := NewQAEqual("index", "777")
-	f4 := NewQARegex("flavor", "sour")
+	f1 := Regex("color", "^x")
+	f2 := Regex("animal", "mo{3,5}se")
+	f3 := Equal("index", "777")
+	f4 := Regex("flavor", "sour")
 
-	runQATest(t, a, NewQANot(t1), false)
-	runQATest(t, a, NewQANot(t2), false)
-	runQATest(t, a, NewQANot(t3), false)
-	runQATest(t, a, NewQANot(t4), false)
-	runQATest(t, a, NewQANot(f1), true)
-	runQATest(t, a, NewQANot(f2), true)
-	runQATest(t, a, NewQANot(f3), true)
-	runQATest(t, a, NewQANot(f4), true)
+	runQATest(t, a, Not(t1), false)
+	runQATest(t, a, Not(t2), false)
+	runQATest(t, a, Not(t3), false)
+	runQATest(t, a, Not(t4), false)
+	runQATest(t, a, Not(f1), true)
+	runQATest(t, a, Not(f2), true)
+	runQATest(t, a, Not(f3), true)
+	runQATest(t, a, Not(f4), true)
 }
 
 func TestAttrAnd(t *testing.T) {
 	a := testGetAttrs()
 
 	// things that are true
-	t1 := NewQAEqual("color", "blue")
-	t2 := NewQAEqual("animal", "moose")
-	t3 := NewQARegex("index", `^\d+$`)
-	t4 := NewQAEqual("shape", "square")
+	t1 := Equal("color", "blue")
+	t2 := Equal("animal", "moose")
+	t3 := Regex("index", `^\d+$`)
+	t4 := Equal("shape", "square")
 
 	// things that are false
-	f1 := NewQARegex("color", "^x")
-	f2 := NewQARegex("animal", "mo{3,5}se")
-	f3 := NewQAEqual("index", "777")
-	f4 := NewQARegex("flavor", "sour")
+	f1 := Regex("color", "^x")
+	f2 := Regex("animal", "mo{3,5}se")
+	f3 := Equal("index", "777")
+	f4 := Regex("flavor", "sour")
 
-	runQATest(t, a, NewQAAnd(), false)
-	runQATest(t, a, NewQAAnd(t1), true)
-	runQATest(t, a, NewQAAnd(t1, t2), true)
-	runQATest(t, a, NewQAAnd(t1, t2, t3, t4), true)
-	runQATest(t, a, NewQAAnd(f1), false)
-	runQATest(t, a, NewQAAnd(t1, f1), false)
-	runQATest(t, a, NewQAAnd(t1, t2, t3, t4, f1), false)
-	runQATest(t, a, NewQAAnd(f1, f2, f3, f4), false)
+	runQATest(t, a, And(), false)
+	runQATest(t, a, And(t1), true)
+	runQATest(t, a, And(t1, t2), true)
+	runQATest(t, a, And(t1, t2, t3, t4), true)
+	runQATest(t, a, And(f1), false)
+	runQATest(t, a, And(t1, f1), false)
+	runQATest(t, a, And(t1, t2, t3, t4, f1), false)
+	runQATest(t, a, And(f1, f2, f3, f4), false)
 }
 
 func TestAttrOr(t *testing.T) {
 	a := testGetAttrs()
 
 	// things that are true
-	t1 := NewQAEqual("color", "blue")
-	t2 := NewQAEqual("animal", "moose")
-	t3 := NewQARegex("index", `^\d+$`)
-	t4 := NewQAEqual("shape", "square")
+	t1 := Equal("color", "blue")
+	t2 := Equal("animal", "moose")
+	t3 := Regex("index", `^\d+$`)
+	t4 := Equal("shape", "square")
 
 	// things that are false
-	f1 := NewQARegex("color", "^x")
-	f2 := NewQARegex("animal", "mo{3,5}se")
-	f3 := NewQAEqual("index", "777")
-	f4 := NewQARegex("flavor", "sour")
+	f1 := Regex("color", "^x")
+	f2 := Regex("animal", "mo{3,5}se")
+	f3 := Equal("index", "777")
+	f4 := Regex("flavor", "sour")
 
-	runQATest(t, a, NewQAOr(), false)
-	runQATest(t, a, NewQAOr(t1), true)
-	runQATest(t, a, NewQAOr(t1, t2), true)
-	runQATest(t, a, NewQAOr(t1, t2, t3, t4), true)
-	runQATest(t, a, NewQAOr(f1), false)
-	runQATest(t, a, NewQAOr(t1, f1), true)
-	runQATest(t, a, NewQAOr(t1, t2, t3, t4, f1), true)
-	runQATest(t, a, NewQAOr(f1, f2, f3, f4), false)
+	runQATest(t, a, Or(), false)
+	runQATest(t, a, Or(t1), true)
+	runQATest(t, a, Or(t1, t2), true)
+	runQATest(t, a, Or(t1, t2, t3, t4), true)
+	runQATest(t, a, Or(f1), false)
+	runQATest(t, a, Or(t1, f1), true)
+	runQATest(t, a, Or(t1, t2, t3, t4, f1), true)
+	runQATest(t, a, Or(f1, f2, f3, f4), false)
 }
 func TestAttrLogicCombo(t *testing.T) {
 	a := testGetAttrs()
 
 	// things that are true
-	t1 := NewQAEqual("color", "blue")
-	t2 := NewQAEqual("animal", "moose")
-	t3 := NewQARegex("index", `^\d+$`)
-	t4 := NewQAEqual("shape", "square")
+	t1 := Equal("color", "blue")
+	t2 := Equal("animal", "moose")
+	t3 := Regex("index", `^\d+$`)
+	t4 := Equal("shape", "square")
 
 	// things that are false
-	f1 := NewQARegex("color", "^x")
-	f2 := NewQARegex("animal", "mo{3,5}se")
-	f3 := NewQAEqual("index", "777")
-	f4 := NewQARegex("flavor", "sour")
+	f1 := Regex("color", "^x")
+	f2 := Regex("animal", "mo{3,5}se")
+	f3 := Equal("index", "777")
+	f4 := Regex("flavor", "sour")
 
-	t5 := NewQAOr(t1, f1)
-	t6 := NewQAOr(f2, f3, f4, t2, t3, t4)
-	t7 := NewQAAnd(NewQANot(f1), t1)
+	t5 := Or(t1, f1)
+	t6 := Or(f2, f3, f4, t2, t3, t4)
+	t7 := And(Not(f1), t1)
 
-	f5 := NewQANot(NewQAAnd(t1, t4))
-	f6 := NewQAAnd(NewQANot(f4), f5)
-	f7 := NewQAOr(f2, f4)
+	f5 := Not(And(t1, t4))
+	f6 := And(Not(f4), f5)
+	f7 := Or(f2, f4)
 
-	runQATest(t, a, NewQAOr(f5, f6, f7, t5), true)
-	runQATest(t, a, NewQAAnd(f5, f6, f7, t5), false)
-	runQATest(t, a, NewQAOr(f5, f6, f7), false)
-	runQATest(t, a, NewQAAnd(f5, f6, f7), false)
-	runQATest(t, a, NewQAOr(t5, t6, t7), true)
-	runQATest(t, a, NewQAAnd(t5, t6, t7), true)
+	runQATest(t, a, Or(f5, f6, f7, t5), true)
+	runQATest(t, a, And(f5, f6, f7, t5), false)
+	runQATest(t, a, Or(f5, f6, f7), false)
+	runQATest(t, a, And(f5, f6, f7), false)
+	runQATest(t, a, Or(t5, t6, t7), true)
+	runQATest(t, a, And(t5, t6, t7), true)
 }


### PR DESCRIPTION
Simplify naming of constructor functions for query attributes to make the API more friendly for creating queries.