### PR TITLE
Convert all unit tests to using Testify assertions

### DIFF
--- a/internal/core/id_test.go
+++ b/internal/core/id_test.go
@@ -40,68 +40,43 @@ func TestIdRoundtrip(t *testing.T) {
 		id1 := NewId()
 		s := id1.String()
 		id2, err := IdFromString(s)
-		if err != nil {
-			t.Errorf("failed to create Id from string %s: %s", s, err.Error())
-		}
-
-		if id1.val != id2.val {
-			t.Errorf("Id roundtrip values not equal, expected %d got %d", id1.val, id2.val)
-		}
-
-		if id1.String() != id2.String() {
-			t.Errorf("Id roundtrip strings not equal, expected %s got %s", id1.String(), id2.String())
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, id1.val, id2.val)
+		assert.Equal(t, id1.String(), id2.String())
 	}
 }
 
 func TestIdErrors(t *testing.T) {
-	var id *Id
 	var err error
 	var s, msg string
 
 	// missing the trailing "=" that is padding
 	s = "Jyr3cq4KZ14"
 	msg = "error decoding string 'Jyr3cq4KZ14': illegal base64 data at input byte 8"
-	id, err = IdFromString(s)
-	if err == nil {
-		t.Errorf("expected error when parsing %s, got success (%d, %s)", s, id.val, id.String())
-	} else if err.Error() != msg {
-		t.Errorf("unexpected error message when parsing %s: expected '%s' got '%s'",
-			s, msg, err.Error())
-	}
+	_, err = IdFromString(s)
+	assert.NotNil(t, err)
+	assert.Equal(t, msg, err.Error())
 
 	// garbage
 	s = "Jyr$*#()"
 	msg = "error decoding string 'Jyr$*#()': illegal base64 data at input byte 3"
-	id, err = IdFromString(s)
-	if err == nil {
-		t.Errorf("expected error when parsing %s, got success (%d, %s)", s, id.val, id.String())
-	} else if err.Error() != msg {
-		t.Errorf("unexpected error message when parsing %s: expected '%s' got '%s'",
-			s, msg, err.Error())
-	}
+	_, err = IdFromString(s)
+	assert.NotNil(t, err)
+	assert.Equal(t, msg, err.Error())
 
 	// empty string
 	s = ""
 	msg = "invalid num bytes 0 when decoding string ''"
-	id, err = IdFromString(s)
-	if err == nil {
-		t.Errorf("expected error when parsing %s, got success (%d, %s)", s, id.val, id.String())
-	} else if err.Error() != msg {
-		t.Errorf("unexpected error message when parsing %s: expected '%s' got '%s'",
-			s, msg, err.Error())
-	}
+	_, err = IdFromString(s)
+	assert.NotNil(t, err)
+	assert.Equal(t, msg, err.Error())
 
 	// partial string
 	s = "Jyr3cq4K"
 	msg = "invalid num bytes 6 when decoding string 'Jyr3cq4K'"
-	id, err = IdFromString(s)
-	if err == nil {
-		t.Errorf("expected error when parsing %s, got success (%d, %s)", s, id.val, id.String())
-	} else if err.Error() != msg {
-		t.Errorf("unexpected error message when parsing %s: expected '%s' got '%s'",
-			s, msg, err.Error())
-	}
+	_, err = IdFromString(s)
+	assert.NotNil(t, err)
+	assert.Equal(t, msg, err.Error())
 }
 
 func TestIdCmp(t *testing.T) {
@@ -110,10 +85,7 @@ func TestIdCmp(t *testing.T) {
 
 	fn := func(i1 *Id, i2 *Id, exp int) {
 		act := i1.Cmp(i2)
-		if act != exp {
-			t.Errorf("error comparing [%d]%s to [%d]%s: expected %d got %d",
-				i1.val, i1.String(), i2.val, i2.String(), exp, act)
-		}
+		assert.Equal(t, exp, act)
 	}
 
 	fn(id1, id2, -1)

--- a/internal/core/point_test.go
+++ b/internal/core/point_test.go
@@ -12,34 +12,12 @@ func TestPointCreate(t *testing.T) {
 
 	ts := time.Date(2024, 01, 10, 23, 1, 2, 0, time.UTC)
 	p := NewPoint(ts)
-
-	if ts != p.Ts {
-		t.Errorf("Got %s, wanted %s", p.Ts.UTC(), ts.UTC())
-	}
-
-	if p.Vals == nil {
-		t.Errorf("Values is nil")
-	}
-
-	if len(p.Vals) != 0 {
-		t.Errorf("Expected 0 values, got %d", len(p.Vals))
-	}
-
-	if p.Attrs == nil {
-		t.Errorf("Attrs is nil")
-	}
-
-	if len(p.Attrs) != 0 {
-		t.Errorf("Expected 0 attributes, got %d", len(p.Attrs))
-	}
-
-	if p.Id.val <= 0 {
-		t.Errorf("Expected an id >= 0, got %d", p.Id.val)
-	}
-
-	if p.Id.String() == "" {
-		t.Errorf("Expected an id, got empty string")
-	}
+	assert.Equal(t, ts, p.Ts)
+	assert.NotNil(t, p.Vals)
+	assert.Equal(t, 0, len(p.Vals))
+	assert.NotNil(t, p.Attrs)
+	assert.Equal(t, 0, len(p.Attrs))
+	assert.NotEqual(t, "", p.Id.String())
 
 	// generate new Id and make sure it is different
 	oldId := p.Id.String()
@@ -51,29 +29,12 @@ func TestPointCreateEmptyId(t *testing.T) {
 	ts := time.Date(2024, 01, 10, 23, 1, 2, 0, time.UTC)
 	p := NewPointEmptyId(ts)
 
-	if ts != p.Ts {
-		t.Errorf("Got %s, wanted %s", p.Ts.UTC(), ts.UTC())
-	}
-
-	if p.Vals == nil {
-		t.Errorf("Values is nil")
-	}
-
-	if len(p.Vals) != 0 {
-		t.Errorf("Expected 0 values, got %d", len(p.Vals))
-	}
-
-	if p.Attrs == nil {
-		t.Errorf("Attrs is nil")
-	}
-
-	if len(p.Attrs) != 0 {
-		t.Errorf("Expected 0 attributes, got %d", len(p.Attrs))
-	}
-
-	if p.Id != nil {
-		t.Errorf("Expected an id of nil, got %d", p.Id.val)
-	}
+	assert.Equal(t, ts, p.Ts)
+	assert.NotNil(t, p.Vals)
+	assert.Equal(t, 0, len(p.Vals))
+	assert.NotNil(t, p.Attrs)
+	assert.Equal(t, 0, len(p.Attrs))
+	assert.Nil(t, p.Id)
 }
 
 func TestPointCreateEmpty(t *testing.T) {
@@ -81,29 +42,12 @@ func TestPointCreateEmpty(t *testing.T) {
 	ts := time.Time{}
 	p := NewPointEmpty()
 
-	if ts != p.Ts { // empty
-		t.Errorf("Got %s, wanted %s", p.Ts.UTC(), ts.UTC())
-	}
-
-	if p.Vals == nil {
-		t.Errorf("Values is nil")
-	}
-
-	if len(p.Vals) != 0 {
-		t.Errorf("Expected 0 values, got %d", len(p.Vals))
-	}
-
-	if p.Attrs == nil {
-		t.Errorf("Attrs is nil")
-	}
-
-	if len(p.Attrs) != 0 {
-		t.Errorf("Expected 0 attributes, got %d", len(p.Attrs))
-	}
-
-	if p.Id != nil {
-		t.Errorf("Expected an id of nil, got %d", p.Id.val)
-	}
+	assert.Equal(t, ts, p.Ts)
+	assert.NotNil(t, p.Vals)
+	assert.Equal(t, 0, len(p.Vals))
+	assert.NotNil(t, p.Attrs)
+	assert.Equal(t, 0, len(p.Attrs))
+	assert.Nil(t, p.Id)
 }
 
 func testNewPointComplete() *Point {
@@ -157,17 +101,12 @@ func TestPointCreateComplete(t *testing.T) {
 	p := testNewPointComplete()
 	ts := time.Date(2024, 01, 10, 23, 1, 2, 0, time.UTC)
 
-	if ts != p.Ts {
-		t.Errorf("Got %s, wanted %s", p.Ts.UTC(), ts.UTC())
-	}
-
-	if len(p.Vals) != 2 {
-		t.Errorf("Expected 2 values, got %d", len(p.Vals))
-	}
-
-	if len(p.Attrs) != 2 {
-		t.Errorf("Expected 2 attributes, got %d", len(p.Attrs))
-	}
+	assert.Equal(t, ts, p.Ts)
+	assert.NotNil(t, p.Vals)
+	assert.Equal(t, 2, len(p.Vals))
+	assert.NotNil(t, p.Attrs)
+	assert.Equal(t, 2, len(p.Attrs))
+	assert.NotNil(t, p.Id)
 }
 
 func TestPointEqual(t *testing.T) {
@@ -175,27 +114,19 @@ func TestPointEqual(t *testing.T) {
 
 	cmp := func(pt1 *Point, pt2 *Point, exp int) {
 		act := PointCmp(pt1, pt2)
-		if act != exp {
-			t.Errorf("PointCmp(%s, %s) expected %d got %d", pt1.String(), pt2.String(), exp, act)
-		}
+		assert.Equal(t, exp, act)
 	}
 
 	{ // basic equality
 		p2 := testNewPointComplete()
-		if !p1.Equal(p2) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p1.String(), p2.String())
-		}
-
+		assert.True(t, p1.Equal(p2))
 		cmp(p1, p2, 0)
 	}
 
 	{ // different timestamp
 		p2 := testNewPointComplete()
 		p2.Ts = p2.Ts.AddDate(0, 0, 1)
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
-
+		assert.False(t, p1.Equal(p2))
 		cmp(p1, p2, -1)
 		cmp(p2, p1, 1)
 	}
@@ -205,60 +136,31 @@ func TestPointEqual(t *testing.T) {
 		cmp(p1, p2, 0)
 		p2.Vals["area"] = 43.1004
 		cmp(p1, p2, 0) // only timestamp matters
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.False(t, p1.Equal(p2))
 
-		if !p1.EqualTol(p2, 0.1) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p1.String(), p2.String())
-		}
-
-		if !p1.EqualTol(p2, 0.01) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p1.String(), p2.String())
-		}
-
-		if !p1.EqualTol(p2, 0.001) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p1.String(), p2.String())
-		}
-
-		if !p1.EqualTol(p2, 0.0001) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p1.String(), p2.String())
-		}
-
-		if !p1.EqualTol(p2, 0.00001) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p1.String(), p2.String())
-		}
-
-		if p1.EqualTol(p2, 0.000001) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
-
-		if p1.EqualTol(p2, 0.0000001) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.True(t, p1.EqualTol(p2, 0.1))
+		assert.True(t, p1.EqualTol(p2, 0.01))
+		assert.True(t, p1.EqualTol(p2, 0.001))
+		assert.True(t, p1.EqualTol(p2, 0.0001))
+		assert.True(t, p1.EqualTol(p2, 0.00001))
+		assert.False(t, p1.EqualTol(p2, 0.000001))
+		assert.False(t, p1.EqualTol(p2, 0.0000001))
 
 		// test 0.00 value
 		p2.Vals["area"] = 0.000
-		if !p2.EqualTol(p2, 0.001) {
-			t.Errorf("Expected equal, got inequal: %s compared to %s", p2.String(), p2.String())
-		}
-
+		assert.True(t, p2.EqualTol(p2, 0.001))
 	}
 
 	{ // add value
 		p2 := testNewPointComplete()
 		p2.Vals["area2"] = 49.999
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.False(t, p1.Equal(p2))
 	}
 
 	{ // delete value
 		p2 := testNewPointComplete()
 		delete(p2.Vals, "area")
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.False(t, p1.Equal(p2))
 	}
 
 	{ // changed attr
@@ -266,9 +168,7 @@ func TestPointEqual(t *testing.T) {
 		cmp(p1, p2, 0)
 		p2.Attrs["color"] = "blue"
 		cmp(p1, p2, 0) // only timestamp matters
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.False(t, p1.Equal(p2))
 	}
 
 	{ // add attr
@@ -276,17 +176,13 @@ func TestPointEqual(t *testing.T) {
 		cmp(p1, p2, 0)
 		p2.Attrs["color2"] = "blue"
 		cmp(p1, p2, 0) // only timestamp matters
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.False(t, p1.Equal(p2))
 	}
 
 	{ // delete attr
 		p2 := testNewPointComplete()
 		delete(p2.Attrs, "color")
-		if p1.Equal(p2) {
-			t.Errorf("Expected inequal, got equal: %s compared to %s", p1.String(), p2.String())
-		}
+		assert.False(t, p1.Equal(p2))
 	}
 }
 
@@ -305,10 +201,7 @@ func TestPointIdentical(t *testing.T) {
 
 	fn := func(pt1 *Point, pt2 *Point, exp bool) {
 		act := pt1.Identical(pt2)
-		if act != exp {
-			t.Errorf("Expected identity %t got %t: [%s]%s compared to [%s]%s",
-				exp, act, pt1.Id.String(), pt1.String(), pt2.Id.String(), pt2.String())
-		}
+		assert.Equal(t, exp, act)
 	}
 
 	fn(p1, p2, false)
@@ -345,34 +238,19 @@ func TestPointClone(t *testing.T) {
 	p2 := p1.Clone()
 
 	// these should be identical and equal
-	if !p1.Equal(p2) {
-		t.Errorf("Expected equal but got inequal: [%s]%s compared to [%s]%s",
-			p1.Id.String(), p1.String(), p2.Id.String(), p2.String())
-	}
-
-	if !p1.Identical(p2) {
-		t.Errorf("Expected identical but got different: [%s]%s compared to [%s]%s",
-			p1.Id.String(), p1.String(), p2.Id.String(), p2.String())
-	}
+	assert.True(t, p1.Equal(p2))
+	assert.True(t, p1.Identical(p2))
 
 	// if we change one it shouldn't affect the other
 	p1.Attrs["shape"] = "triangle"
-	if p2.Attrs["shape"] != "square" {
-		t.Errorf("changing p1.Attrs[shape] to triangle also changed p2.Attrs[shape] to %s", p2.Attrs["shape"])
-	}
+	assert.Equal(t, "square", p2.Attrs["shape"])
 
 	p1.Vals["area"] = 1.0
-	if p2.Vals["area"] != 43.1 {
-		t.Errorf("changing p1.Vals[area] to triangle also changed p2.Vals[area] to %f", p2.Vals["area"])
-	}
+	assert.Equal(t, 43.1, p2.Vals["area"])
 
 	p1.Ts = time.Date(2024, 01, 11, 23, 1, 2, 0, time.UTC)
-	if p2.Ts.String() != "2024-01-10 23:01:02 +0000 UTC" {
-		t.Errorf("changing p1.Ts to %s also changed p2.Ts to %s", p1.Ts.String(), p2.Ts.String())
-	}
+	assert.Equal(t, "2024-01-10 23:01:02 +0000 UTC", p2.Ts.String())
 
 	p1.Id.val = 3
-	if p2.Id.val == 3 {
-		t.Errorf("changing p1.Id to 3 also changed p2.Id to 3")
-	}
+	assert.NotEqual(t, 3, p2.Id.val)
 }

--- a/internal/engine/memlist_test.go
+++ b/internal/engine/memlist_test.go
@@ -3,26 +3,21 @@ package engine
 import (
 	"equinox/internal/core"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMemListConstructBasic(t *testing.T) {
 	ml := NewMemList()
 	ps := getPoints(0, 10)
 	var err error
-
-	if ml.Len() != 0 {
-		t.Fatalf("incorrect length expected 0 got %d", ml.Len())
-	}
+	assert.Equal(t, 0, ml.Len())
 
 	runtest := func(p []*core.Point, len int) {
 		ml.Add(p)
 		err = ml.validate()
-		if err != nil {
-			t.Fatalf("validation failed: %s", err.Error())
-		}
-		if ml.Len() != len {
-			t.Fatalf("incorrect length expected %d got %d", len, ml.Len())
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, len, ml.Len())
 	}
 
 	runtest(make([]*core.Point, 0), 0)
@@ -38,20 +33,14 @@ func TestMemListConstructBasic(t *testing.T) {
 func TestMemListString(t *testing.T) {
 	ml := NewMemList()
 
-	exp := "MemList"
-	if ml.Name() != exp {
-		t.Errorf("incorrect Name: expected %s got %s", exp, ml.Name())
-	}
+	assert.Equal(t, "MemList", ml.Name())
 
 	ml.Add(getPoints(5, 2))
-	exp = `MemList: {
+	exp := `MemList: {
 0: [2024-01-10 23:06:02 +0000 UTC] val[area: -0.958924, temp: 0.283662] attr[animal: pig, color: purple, shape: circle]
 1: [2024-01-10 23:07:02 +0000 UTC] val[area: -0.279415, temp: 0.960170] attr[animal: pig, color: purple, shape: circle]
 }`
-	act := ml.String()
-	if exp != act {
-		t.Errorf("incorect MemList string: expected '%s' got '%s'", exp, act)
-	}
+	assert.Equal(t, exp, ml.String())
 }
 
 func TestMemListConstructBatches(t *testing.T) {
@@ -67,26 +56,18 @@ func TestMemListConstructBatches(t *testing.T) {
 		pbatch = append(pbatch, p)
 		if len(pbatch) >= batch { // add in batches
 			err = ml.Add(pbatch)
-			if err != nil {
-				t.Fatalf("unexpected error when adding %d points: %s", len(pbatch), err.Error())
-			}
+			assert.Nil(t, err)
 			err = ml.validate()
-			if err != nil {
-				t.Fatalf("Validation failed: %s", err.Error())
-			}
+			assert.Nil(t, err)
 			pbatch = nil
 		}
 	}
 
 	if len(pbatch) > 0 { // final batch
 		ml.Add(pbatch)
-		if err != nil {
-			t.Fatalf("unexpected error when adding %d points: %s", len(pbatch), err.Error())
-		}
+		assert.Nil(t, err)
 		err = ml.validate()
-		if err != nil {
-			t.Fatalf("Validation failed: %s", err.Error())
-		}
+		assert.Nil(t, err)
 		pbatch = nil
 	}
 }

--- a/internal/engine/memtree_test.go
+++ b/internal/engine/memtree_test.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"equinox/internal/core"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMemTreeQuery(t *testing.T) {
@@ -18,35 +20,25 @@ func TestMemTreeQuery(t *testing.T) {
 
 func TestMemTreeString(t *testing.T) {
 	mt := NewMemTree()
-
-	exp := "MemTree"
-	if mt.Name() != exp {
-		t.Errorf("incorrect Name: expected %s got %s", exp, mt.Name())
-	}
+	assert.Equal(t, "MemTree", mt.Name())
 
 	mt.Add(getPoints(5, 2))
-	exp = `MemTree: {
+	exp := `MemTree: {
 0: [2024-01-10 23:06:02 +0000 UTC] val[area: -0.958924, temp: 0.283662] attr[animal: pig, color: purple, shape: circle]
 1: [2024-01-10 23:07:02 +0000 UTC] val[area: -0.279415, temp: 0.960170] attr[animal: pig, color: purple, shape: circle]
 }`
-	act := mt.String()
-	if exp != act {
-		t.Errorf("incorect MemTree string: expected '%s' got '%s'", exp, act)
-	}
+
+	assert.Equal(t, exp, mt.String())
 }
 func TestMemTreeConstructBasic(t *testing.T) {
 	mt := NewMemTree()
 	ps := getPoints(0, 10)
 
-	if mt.Len() != 0 {
-		t.Fatalf("incorrect length expected 0 got %d", mt.Len())
-	}
+	assert.Equal(t, 0, mt.Len())
 
 	runtest := func(p []*core.Point, len int) {
 		mt.Add(p)
-		if mt.Len() != len {
-			t.Fatalf("incorrect length expected %d got %d", len, mt.Len())
-		}
+		assert.Equal(t, len, mt.Len())
 	}
 
 	runtest(make([]*core.Point, 0), 0)

--- a/internal/file/attrmap_test.go
+++ b/internal/file/attrmap_test.go
@@ -2,6 +2,8 @@ package file
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBasic(t *testing.T) {
@@ -11,36 +13,16 @@ func TestBasic(t *testing.T) {
 	//s3 := "3.14"
 
 	m := NewAttrMap()
-
-	if m.Length() != 0 {
-		t.Errorf("Length: got %d, wanted %d", m.Length(), 0)
-	}
-
-	if m.HasIndex(i1) {
-		t.Errorf("Exist: index %d exists when it shouldn't", i1)
-	}
-
-	if m.HasAttr(s1) {
-		t.Errorf("Exist: attr %s exists when it shouldn't", s1)
-	}
+	assert.Equal(t, uint32(0), m.Length())
+	assert.False(t, m.HasIndex(i1))
+	assert.False(t, m.HasAttr(s1))
 
 	i1 = m.ToIndex(s1)
 
-	if i1 != 0 {
-		t.Errorf("Add: got index %d for attr %s expected %d", i1, s1, 0)
-	}
-
-	if !m.HasIndex(i1) {
-		t.Errorf("Exist: index %d for attr %s is missing", i1, s1)
-	}
-
-	if !m.HasAttr(s1) {
-		t.Errorf("Exist: attr %s is missing", s1)
-	}
-
-	if m.Length() != 1 {
-		t.Errorf("Length: got %d, wanted %d", m.Length(), 1)
-	}
+	assert.Equal(t, uint32(0), i1)
+	assert.True(t, m.HasIndex(i1))
+	assert.True(t, m.HasAttr(s1))
+	assert.Equal(t, uint32(1), m.Length())
 }
 
 func TestMultiple(t *testing.T) {
@@ -53,37 +35,20 @@ func TestMultiple(t *testing.T) {
 	i2 := m.ToIndex(s2)
 	i3 := m.ToIndex(s3)
 
-	if m.Length() != 3 {
-		t.Errorf("Length: got %d, wanted %d", m.Length(), 3)
-	}
+	assert.Equal(t, uint32(3), m.Length())
 
 	// make sure indexes work
 	str1, exist := m.AtIndex(i1)
-	if !exist {
-		t.Errorf("AtIndex: index %d for attr %s is missing", i1, s1)
-	}
-
-	if s1 != str1 {
-		t.Errorf("AtIndex: index %d got attr %s, expected %s", i1, str1, s1)
-	}
+	assert.True(t, exist)
+	assert.Equal(t, s1, str1)
 
 	str2, exist := m.AtIndex(i2)
-	if !exist {
-		t.Errorf("AtIndex: index %d for attr %s is missing", i2, s2)
-	}
-
-	if s2 != str2 {
-		t.Errorf("AtIndex: index %d got attr %s, expected %s", i2, str2, s2)
-	}
+	assert.True(t, exist)
+	assert.Equal(t, s2, str2)
 
 	str3, exist := m.AtIndex(i3)
-	if !exist {
-		t.Errorf("AtIndex: index %d for attr %s is missing", i3, s3)
-	}
-
-	if s3 != str3 {
-		t.Errorf("AtIndex: index %d got attr %s, expected %s", i3, str3, s3)
-	}
+	assert.True(t, exist)
+	assert.Equal(t, s3, str3)
 }
 
 func TestDelete(t *testing.T) {
@@ -95,49 +60,29 @@ func TestDelete(t *testing.T) {
 	i1 := m.ToIndex(s1)
 	i2 := m.ToIndex(s2)
 
-	if m.Length() != 2 {
-		t.Errorf("Length: got %d, wanted %d", m.Length(), 2)
-	}
+	assert.Equal(t, uint32(2), m.Length())
 
 	// make sure indexes work
 	str1, exist := m.AtIndex(i1)
-	if !exist {
-		t.Errorf("AtIndex: index %d for attr %s is missing", i1, s1)
-	}
-
-	if s1 != str1 {
-		t.Errorf("AtIndex: index %d got attr %s, expected %s", i1, str1, s1)
-	}
+	assert.True(t, exist)
+	assert.Equal(t, s1, str1)
 
 	str2, exist := m.AtIndex(i2)
-	if !exist {
-		t.Errorf("AtIndex: index %d for attr %s is missing", i2, s2)
-	}
-
-	if s2 != str2 {
-		t.Errorf("AtIndex: index %d got attr %s, expected %s", i2, str2, s2)
-	}
+	assert.True(t, exist)
+	assert.Equal(t, s2, str2)
 
 	// test deletion
 	m.DeleteAttr(s2)
 
-	if m.Length() != 1 {
-		t.Errorf("Length: got %d, wanted %d", m.Length(), 1)
-	}
+	assert.Equal(t, uint32(1), m.Length())
 
 	m.DeleteAttr(s2) // should be a no-op
-	if m.Length() != 1 {
-		t.Errorf("Length: got %d, wanted %d", m.Length(), 1)
-	}
+	assert.Equal(t, uint32(1), m.Length())
 
 	_, exist = m.AtIndex(i2)
-	if exist {
-		t.Errorf("AtIndex: index %d for attr %s still exists", i2, s2)
-	}
+	assert.False(t, exist)
 
 	// test index when adding another
 	i3 := m.ToIndex(s3)
-	if i3 != 2 {
-		t.Errorf("ToIndex: %s was given index %d, expected %d", s3, i3, 2)
-	}
+	assert.Equal(t, uint32(2), i3)
 }

--- a/internal/file/datafile_test.go
+++ b/internal/file/datafile_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func getPoint(i uint32) *core.Point {
@@ -45,9 +47,7 @@ func tempFileName() (string, error) {
 
 func TestDFNew(t *testing.T) {
 	fn, err := tempFileName()
-	if err != nil {
-		t.Fatalf("failed to get temp file name: %s", err.Error())
-	}
+	assert.Nil(t, err)
 	defer os.Remove(fn)
 
 	ser := NewSerializer()
@@ -55,18 +55,14 @@ func TestDFNew(t *testing.T) {
 	b, _ := ser.Serialize(getPoint(0))
 
 	df, err := OpenNewDF(fn, ser, uint32(len(b)))
-	if err != nil {
-		t.Fatalf("failed to open file %s with recsize %d: %s", fn, len(b), err.Error())
-	}
+	assert.Nil(t, err)
 	defer df.Close()
 
 	var i uint32
 	for i = 0; i < 10; i++ {
 		p := getPoint(i)
 		err := df.Write(i, p)
-		if err != nil {
-			t.Errorf("error while reading point %d: %s", i, err.Error())
-		}
+		assert.Nil(t, err)
 	}
 
 	// read back from the same DataFile
@@ -74,59 +70,38 @@ func TestDFNew(t *testing.T) {
 		p := getPoint(i)
 		p2, err := df.Read(i)
 
-		if err != nil {
-			t.Errorf("error while reading point %d: %s", i, err.Error())
-			continue
-		}
-
-		if !p.Equal(p2) {
-			t.Errorf("expected %s, got %s", p.String(), p2.String())
-		}
+		assert.Nil(t, err)
+		assert.True(t, p.Equal(p2))
 	}
 
 	// read back from a new DataFile object
 	df2, err := OpenExistingDF(fn, ser)
-	if err != nil {
-		t.Fatalf("failed to open existing file %s: %s", fn, err.Error())
-	}
+	assert.Nil(t, err)
 
 	for i = 9; i >= 1; i-- {
 		p := getPoint(i)
 		p2, err := df2.Read(i)
 
-		if err != nil {
-			t.Errorf("error while reading point %d: %s", i, err.Error())
-			continue
-		}
-
-		if !p.Equal(p2) {
-			t.Errorf("expected %s, got %s", p.String(), p2.String())
-		}
+		assert.Nil(t, err)
+		assert.True(t, p.Equal(p2))
 	}
-
 }
 
 func TestDFMissing(t *testing.T) {
 	fn, err := tempFileName()
-	if err != nil {
-		t.Fatalf("failed to get temp file name: %s", err.Error())
-	}
+	assert.Nil(t, err)
 	defer os.Remove(fn)
 
 	ser := NewSerializer()
 
 	_, err = OpenExistingDF(fn, ser)
-	if err == nil {
-		t.Fatalf("expected to fail to open non-existent file %s", fn)
-	}
+	assert.NotNil(t, err)
 }
 
 // tests writing/reading non-sequential points
 func TestDFNonseq(t *testing.T) {
 	fn, err := tempFileName()
-	if err != nil {
-		t.Fatalf("failed to get temp file name: %s", err.Error())
-	}
+	assert.Nil(t, err)
 	defer os.Remove(fn)
 
 	ser := NewSerializer()
@@ -134,9 +109,7 @@ func TestDFNonseq(t *testing.T) {
 	b, _ := ser.Serialize(getPoint(0))
 
 	df, err := OpenNewDF(fn, ser, uint32(len(b)))
-	if err != nil {
-		t.Fatalf("failed to open file %s with recsize %d: %s", fn, len(b), err.Error())
-	}
+	assert.Nil(t, err)
 	defer df.Close()
 
 	// write points 0, 2
@@ -148,32 +121,19 @@ func TestDFNonseq(t *testing.T) {
 		p := getPoint(uint32(i))
 		p2, err := df.Read(uint32(i))
 
-		if err != nil {
-			t.Errorf("error while reading point %d: %s", i, err.Error())
-		}
-
-		if !p.Equal(p2) {
-			t.Errorf("expected %s, got %s", p.String(), p2.String())
-		}
+		assert.Nil(t, err)
+		assert.True(t, p.Equal(p2))
 	}
 
 	// point 3+ should fail
 	for i := 3; i < 600; i += 100 {
-		p2, err := df.Read(uint32(i))
-		if err == nil {
-			t.Errorf("should have failed to read point %d; got %s", i, p2.String())
-		} else {
-			//t.Logf("correctly got error when reading point %d: %s", i, err.Error())
-		}
+		_, err := df.Read(uint32(i))
+		assert.NotNil(t, err)
 	}
 
 	// point 1 should fail
 	for i := 1; i < 2; i++ {
-		p2, err := df.Read(uint32(i))
-		if err == nil {
-			t.Errorf("should have failed to read point %d; got %s", i, p2.String())
-		} else {
-			//t.Logf("correctly got error when reading point %d: %s", i, err.Error())
-		}
+		_, err := df.Read(uint32(i))
+		assert.NotNil(t, err)
 	}
 }

--- a/internal/file/serializer_test.go
+++ b/internal/file/serializer_test.go
@@ -4,6 +4,8 @@ import (
 	"equinox/internal/core"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSerialize(t *testing.T) {
@@ -11,10 +13,7 @@ func TestSerialize(t *testing.T) {
 	const exptime string = "2024-01-10T23:01:02.000000Z"
 	const fmtstr string = "2006-01-02T15:04:05.000000Z"
 
-	if ts.Format(fmtstr) != exptime {
-		t.Errorf("Time format incorrect, expected %s got %s for UTC time %s",
-			exptime, ts.Format(fmtstr), ts.UTC())
-	}
+	assert.Equal(t, exptime, ts.Format(fmtstr))
 
 	p := core.NewPoint(ts)
 	p.Attrs["color"] = "red"
@@ -26,24 +25,14 @@ func TestSerialize(t *testing.T) {
 
 	data, err := s.Serialize(p)
 
-	if err != nil {
-		t.Errorf("Serialization error: %s", err.Error())
-	}
+	assert.Nil(t, err)
 
 	// expected size: 16 + 12*num_values + 8*num_attrs = 16 + 24 + 16 = 56
-	expsize := 56
-	if len(data) != expsize {
-		t.Errorf("Serialization returned %d bytes, expected %d", len(data), expsize)
-	}
+	assert.Equal(t, 56, len(data))
 
 	p2, err := s.Deserialize(data)
 
-	if err != nil {
-		t.Errorf("Deserialization error: %s", err.Error())
-	}
-
-	if !p2.Equal(p) {
-		t.Errorf("Expected %s, got %s", p.String(), p2.String())
-	}
+	assert.Nil(t, err)
+	assert.True(t, p2.Equal(p))
 
 }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -4,6 +4,8 @@ import (
 	"equinox/internal/core"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreate(t *testing.T) {
@@ -12,15 +14,12 @@ func TestCreate(t *testing.T) {
 
 	q := NewQuery(t2, t4, True())
 	exp := "[2024-01-12 13:00:00 +0000 UTC-2024-01-14 13:00:00 +0000 UTC] [true]"
-	if q.String() != exp {
-		t.Errorf("expected string %s got %s", exp, q.String())
-	}
+
+	assert.Equal(t, exp, q.String())
 
 	// make sure start/end inversion is accounted for
 	q = NewQuery(t4, t2, True())
-	if q.String() != exp {
-		t.Errorf("expected string %s got %s", exp, q.String())
-	}
+	assert.Equal(t, exp, q.String())
 }
 
 func TestCmpTime(t *testing.T) {
@@ -34,10 +33,7 @@ func TestCmpTime(t *testing.T) {
 
 	fn := func(ts time.Time, exp int) {
 		act := q.CmpTime(core.NewPoint(ts))
-		if act != exp {
-			t.Errorf("checking %s against query %s: expected %d but got %d",
-				ts.UTC(), q.String(), exp, act)
-		}
+		assert.Equal(t, exp, act)
 	}
 
 	fn(t1, -1)
@@ -62,29 +58,14 @@ func TestQueryAttrs(t *testing.T) {
 	p.Attrs["index"] = "74"
 
 	fnsub := func(q *Query, exp_ts bool, exp_attr bool) {
-		var act bool
-
 		// check attr only match
-		act = q.MatchAttr(p)
-		if act != exp_attr {
-			t.Errorf("MatchAttr(%s) for query {{%s}}: expected %t but got %t",
-				p.String(), q.String(), exp_attr, act)
-		}
+		assert.Equal(t, exp_attr, q.MatchAttr(p))
 
 		// check time only match
-		act = q.MatchTime(p)
-		if act != exp_ts {
-			t.Errorf("MatchTime(%s) for query {{%s}}: expected %t but got %t",
-				p.String(), q.String(), exp_ts, act)
-		}
+		assert.Equal(t, exp_ts, q.MatchTime(p))
 
 		// check timestamp+attr match
-		exp_both := exp_ts && exp_attr
-		act = q.Match(p)
-		if act != exp_both {
-			t.Errorf("Match(%s) for query {{%s}}: expected %t but got %t",
-				p.String(), q.String(), exp_both, act)
-		}
+		assert.Equal(t, exp_ts && exp_attr, q.Match(p))
 	}
 
 	fn := func(qa QueryAttr, exp_attr bool) {

--- a/internal/query/queryattr_test.go
+++ b/internal/query/queryattr_test.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testGetAttrs() map[string]string {
@@ -26,21 +28,10 @@ func testAttrsToString(attrs map[string]string) string {
 	return strings.Join(attr, ", ")
 }
 
-func runQATest(t *testing.T, attrs map[string]string, qa QueryAttr, exp bool) {
-	result := qa.Match(attrs)
-
-	if result != exp {
-		t.Errorf("QueryAttr: attrs{{{%s}}} and query{{{%s}}} expected %t got %t",
-			testAttrsToString(attrs), qa.String(), exp, result)
-	}
-}
-
 func TestAttrString(t *testing.T) {
 
 	fn := func(t *testing.T, q QueryAttr, exp string) {
-		if q.String() != exp {
-			t.Errorf("operator string: expected %s got %s", exp, q.String())
-		}
+		assert.Equal(t, exp, q.String())
 	}
 
 	fn(t, True(), "true")
@@ -56,6 +47,10 @@ func TestAttrString(t *testing.T) {
 	fn(t, Or(t2, t3), "(animal == 'moose') || (shape == 'square')")
 	fn(t, And(t2, t3), "(animal == 'moose') && (shape == 'square')")
 	fn(t, And(t2, Not(t3)), "(animal == 'moose') && (!(shape == 'square'))")
+}
+
+func runQATest(t *testing.T, attrs map[string]string, qa QueryAttr, exp bool) {
+	assert.Equal(t, exp, qa.Match(attrs))
 }
 
 func TestAttrTrue(t *testing.T) {


### PR DESCRIPTION
Convert all unit tests to using Testify assertions for simplicity and conciseness.